### PR TITLE
Add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: scala
 scala:
   - 2.13.1
+jobs:
+  include:
+    - script: sbt ++$TRAVIS_SCALA_VERSION test
+    - stage: "Test coverage"
+      script: ./stryker.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License: MIT][license_badge]][license_link]
 [![Contributor Covenant][coc_badge]](CODE-OF-CONDUCT.md)
+[![Mutation testing badge][stryker_badge]][stryker_link]
 
 > De Bruijn graph-based De Novo genome assembly CLI tool
 
@@ -55,3 +56,5 @@ This project is licenced under the terms of the [MIT](LICENSE.md) license.
 [license_badge]: https://img.shields.io/badge/License-MIT-blue.svg
 [coc_badge]: https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg
 [releases_link]: https://github.com/DenisVerkhoturov/geney/releases
+[stryker_badge]: https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FDenisVerkhoturov%2Fgeney%2Fmaster
+[stryker_link]: https://dashboard.stryker-mutator.io/reports/github.com/DenisVerkhoturov/geney/master

--- a/assembler/src/test/scala/graph/DeBruijnGraphSuite.scala
+++ b/assembler/src/test/scala/graph/DeBruijnGraphSuite.scala
@@ -1,9 +1,17 @@
 package graph
 
+import com.github.ghik.silencer.silent
+import org.scalatest.concurrent.{Signaler, TimeLimitedTests}
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{Seconds, Span}
 import org.scalatest.wordspec.AnyWordSpec
 
-class DeBruijnGraphSuite extends AnyWordSpec with Matchers {
+class DeBruijnGraphSuite extends AnyWordSpec with Matchers with TimeLimitedTests {
+  val timeLimit: Span = Span(10, Seconds)
+
+  @silent
+  override val defaultTestSignaler: Signaler = (testThread: Thread) => testThread.stop()
+
   "DeBruijnGraph" should {
     "throw IllegalArgumentException when provided k is less than 2" in {
       an[IllegalArgumentException] should be thrownBy new DeBruijnGraph(LazyList("ACGTCGA"), 0)

--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,9 @@ lazy val utils = project
 
 lazy val commonDependencies = Seq(
   scalastic,
-  scalatest
+  scalatest,
+  silencerPlugin,
+  silencerLib
 )
 
 lazy val formatAll   = taskKey[Unit]("Format all the source code which includes src, test, and build files")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,13 @@ object Dependencies {
   private object Version {
     val scalastic = "3.1.1"
     val scalatest = "3.1.1"
+    val silencer  = "1.6.0"
   }
 
-  val scalastic = "org.scalactic" %% "scalactic" % Version.scalastic % Test
-  val scalatest = "org.scalatest" %% "scalatest" % Version.scalatest % Test
+  val scalastic   = "org.scalactic"   %% "scalactic"   % Version.scalastic % Test
+  val scalatest   = "org.scalatest"   %% "scalatest"   % Version.scalatest % Test
+  val silencerLib = "com.github.ghik" % "silencer-lib" % Version.silencer  % Provided cross CrossVersion.full
+  val silencerPlugin = compilerPlugin(
+    "com.github.ghik" % "silencer-plugin" % Version.silencer % Provided cross CrossVersion.full
+  )
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.2")
+addSbtPlugin("org.scalameta"      % "sbt-scalafmt"  % "2.3.2")
+addSbtPlugin("io.stryker-mutator" % "sbt-stryker4s" % "0.7.2")

--- a/stryker.sh
+++ b/stryker.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+for module in assembler utils cli; do
+  echo "stryker4s {base-dir: $module, reporters: [\"console\", \"dashboard\", \"html\"], dashboard.module=\"$module\"}" >stryker4s.conf
+  if ! sbt "project $module" stryker; then
+    exit
+  fi
+done


### PR DESCRIPTION
Resolves: #16 

После того, как выяснолось, что у `Pitest` нет плагина для `sbt`, я решил продолжить эксперименты со `Stryker4s` и в итоге пришёл к наверное не самому красивому, но рабочему решению: тесты останавливаются с помощью `testThread.stop()`, а предупреждение подавляется с помошью `silencer`.

Так же добавил скрипт для проверки всех модулей и интегрировал его в CI. Если подключим ключ с https://dashboard.stryker-mutator.io, то будет можно добавить в `README.md` плашку с нашим `Mutation score`