### PR TITLE
fix: some changes to cli parser and tests

### DIFF
--- a/cli/src/main/scala/parser/CliParser.scala
+++ b/cli/src/main/scala/parser/CliParser.scala
@@ -3,6 +3,7 @@ package parser
 
 import scopt.{OParser, OParserBuilder}
 import java.io.{File, PrintWriter}
+import java.nio.file.Files
 
 import fasta.Fasta
 import graph.DeBruijnGraph
@@ -26,10 +27,10 @@ class CliParser {
           else failure("Argument -k must be >2") ),
       opt[File]('i', "input")
         .required()
-        .validate(f =>
-          if (!f.exists()) failure("Input file doesn't exist")
-          else if (f.isDirectory) failure("Path to input file is a directory")
-          else if (!f.canRead) failure("Access to input file is denied")
+        .validate(input =>
+          if (!input.exists()) failure("Input file doesn't exist")
+          else if (input.isDirectory) failure("Path to input file is a directory")
+          else if (!Files.isReadable(input.toPath)) failure("Access to input file is denied")
           else success
         )
         .valueName("<file>")
@@ -41,7 +42,7 @@ class CliParser {
         .validate(output =>
           if (output.isDirectory) failure("Path to output file is a directory")
           else if (output.exists()) failure("Output file already exists")
-          else if (!output.getParentFile.canWrite) failure("Access to output file is denied")
+          else if (!Files.isWritable(output.getParentFile.toPath)) failure("Access to output file is denied")
           else success
         )
         .text("output file to write the result to"),

--- a/cli/src/main/scala/parser/CliParser.scala
+++ b/cli/src/main/scala/parser/CliParser.scala
@@ -17,17 +17,19 @@ class CliParser {
     OParser.sequence(
       programName("CliParser"),
       head("CliParser"),
-      opt[Int]('k',"")
+      opt[Int]('k',"k")
+        .required()
         .action((x, c) => c.copy(k = x))
         .text("k is an  integer property, the length of k that will be used to build De Bruijn graph")
         .validate( k =>
           if (k >= 2) success
-          else failure("Option -k must be >2") ),
+          else failure("Argument -k must be >2") ),
       opt[File]('i', "input")
         .required()
         .validate(f =>
-          if (f.exists()) success
-          else failure("Input file doesn't exist.")
+          if (!f.exists()) failure("Input file doesn't exist")
+          else if (f.isDirectory) failure("Path to input file is a directory")
+          else success
         )
         .valueName("<file>")
         .action((x, c) => c.copy(input = x))
@@ -35,7 +37,21 @@ class CliParser {
       opt[File]('o', "output")
         .valueName("<file>")
         .action((x, c) => c.copy(output = x))
+        .validate(output =>
+          if (output.isDirectory) failure("Path to output file is a directory")
+          else if (output.exists()) failure("Output file already exists")
+          else success
+        )
         .text("output file to write the result to"),
+      opt[String]('f', "format")
+        .required()
+        .action((x, c) => c.copy(format = x))
+        .validate {
+          case "fasta" => success
+          case "fastq" => success
+          case "derive" => success
+          case _ => failure("Wrong type of format")
+        },
       help('h',"help").text("show usage"),
     )
   }
@@ -45,7 +61,7 @@ class CliParser {
         println("Args have been parsed successfully.");
         processGraph(config);
       case _ =>
-        println("Couldn't parse args.");
+        System.err.println("Couldn't parse args.");
     }
   }
   private def processGraph(config: CliParserConfig): Unit = {

--- a/cli/src/main/scala/parser/CliParser.scala
+++ b/cli/src/main/scala/parser/CliParser.scala
@@ -29,6 +29,7 @@ class CliParser {
         .validate(f =>
           if (!f.exists()) failure("Input file doesn't exist")
           else if (f.isDirectory) failure("Path to input file is a directory")
+          else if (!f.canRead) failure("Access to input file is denied")
           else success
         )
         .valueName("<file>")
@@ -40,6 +41,7 @@ class CliParser {
         .validate(output =>
           if (output.isDirectory) failure("Path to output file is a directory")
           else if (output.exists()) failure("Output file already exists")
+          else if (!output.getParentFile.canWrite) failure("Access to output file is denied")
           else success
         )
         .text("output file to write the result to"),

--- a/cli/src/main/scala/parser/CliParserConfig.scala
+++ b/cli/src/main/scala/parser/CliParserConfig.scala
@@ -5,5 +5,6 @@ import java.io.File
 case class CliParserConfig(
                    k: Int = -1,
                    input: File = new File("."),
-                   output: File = new File(".")
+                   output: File = new File("."),
+                   format: String = ""
                  )

--- a/e2e/src/test/scala/e2e/FunctionalSpec.scala
+++ b/e2e/src/test/scala/e2e/FunctionalSpec.scala
@@ -57,38 +57,38 @@ class FunctionalSpec extends AnyWordSpec with Matchers with TimeLimitedTests {
     }
     "Incorrect argument -k" should {
       "show error-message when argument -k is not provided" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "--output", "output.txt")
-            Main.main(args);
-          } should have message "Missing option -k"
-        }
+         val args = Array("--input", inputFile.getAbsolutePath, "--output", "output.txt", "-f", "fasta")
+         val out = new ByteArrayOutputStream()
+         Console.withErr(out) {
+           Main.main(args);
+         }
+         out.toString should (include("Missing option --k"))
       }
       "show error-message when argument -k is not positive number" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "-k", "-1")
-            Main.main(args);
-          } should have message "Argument -k must be a positive number"
+        val args = Array("--input", inputFile.getAbsolutePath, "-k", "-1", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Argument -k must be >2"))
       }
       "show error-message when argument -k is not a number" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "-k", "something")
-            Main.main(args);
-          } should have message "Argument -k must be a positive number"
+        val args = Array("--input", inputFile.getAbsolutePath, "-k", "something", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Option --k expects a number"))
       }
     }
     "Incorrect argument --format" should {
       "show error-message when argument -f is not provided" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "-k", "10")
-            Main.main(args);
-          } should have message "Missing option -f"
+        val args = Array("--input", inputFile.getAbsolutePath, "-k", "10")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Missing option --format"))
       }
       "show error-message when argument -f is defined as fasta but content does not correspond" in new Files {
         pendingUntilFixed {
@@ -113,39 +113,39 @@ class FunctionalSpec extends AnyWordSpec with Matchers with TimeLimitedTests {
     }
     "Incorrect argument --input" should {
       "show error-message when input file does not exist" in {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", "PathToFileThatDoesNotExist", "-k", "10")
-            Main.main(args);
-          } should have message "Input file does not exist."
+        val args = Array("--input", "PathToFileThatDoesNotExist", "-k", "10", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Input file doesn't exist"))
       }
       "show error-message when user does not have access to input file" in new Files {
          pendingUntilFixed {
           inputFile.setReadable(false);
           the[AccessDeniedException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "-k", "10")
+            val args = Array("--input", inputFile.getAbsolutePath, "-k", "10", "-f", "fasta")
             Main.main(args);
           } should have message "Access denied"
         }
       }
       "show error-message when path to input file is a directory" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getParent, "-k", "10")
-            Main.main(args);
-          } should have message "Path to input file is a directory."
+        val args = Array("--input", inputFile.getParent, "-k", "10", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Path to input file is a directory"))
       }
     }
     "Incorrect argument --output" should {
       "show error-message when output file already exists" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "--output", outputFile.getAbsolutePath, "-k", "10")
-            Main.main(args);
-          } should have message "Output file already exists."
+        val args = Array("--input", inputFile.getAbsolutePath, "--output", outputFile.getAbsolutePath, "-k", "10", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Output file already exists"))
       }
       "show error-message when user does not have access to output file" in new Files {
         pendingUntilFixed {
@@ -159,12 +159,12 @@ class FunctionalSpec extends AnyWordSpec with Matchers with TimeLimitedTests {
         }
       }
       "show error-message when path to output file is a directory" in new Files {
-        pendingUntilFixed {
-          the[IllegalArgumentException] thrownBy {
-            val args = Array("--input", inputFile.getAbsolutePath, "--output", outputFile.getParent, "-k", "10")
-            Main.main(args);
-          } should have message "Path to input file is a directory."
+        val args = Array("--input", inputFile.getAbsolutePath, "--output", outputFile.getParent, "-k", "10", "-f", "fasta")
+        val out = new ByteArrayOutputStream()
+        Console.withErr(out) {
+          Main.main(args);
         }
+        out.toString should (include("Path to output file is a directory"))
       }
     }
     "Correct arguments" should {


### PR DESCRIPTION
fix: some changes to cli parser and tests to make some tests passed instead of pendinguntilfixed
    1) fixed all test with wrong -k
    2) added option -f and fixed test that checks it's presence
    3) fixed checks for files' existence and for not being directories